### PR TITLE
EmbeddedModelField.get_db_prep_value fix

### DIFF
--- a/djongo/models.py
+++ b/djongo/models.py
@@ -230,7 +230,7 @@ class EmbeddedModelField(Field):
             kwargs['model_form'] = self.model_form
         return name, path, args, kwargs
 
-    def get_db_prep_value(self, value):
+    def get_db_prep_value(self, value, connection=None, prepared=False):
         if not isinstance(value, Model):
             raise TypeError('Object must be of type Model')
 
@@ -238,8 +238,8 @@ class EmbeddedModelField(Field):
         for fld in value._meta.get_fields():
             if not useful_field(fld):
                 continue
-            fld_value = getattr(a_mdl, fld.attname)
-            mdl_ob[fld.attname] = fld.get_db_prep_value(fld_value)
+            fld_value = getattr(value, fld.attname)
+            mdl_ob[fld.attname] = fld.get_db_prep_value(fld_value, connection, prepared)
 
         return mdl_ob
 


### PR DESCRIPTION
Found a small problem when trying to save an instantiated object with an embedded field.

Not sure if I got this wrong, django is still new to me, but on my tests these changes seemed to solve it.