### PR TITLE
features: disable 'has_bulk_insert'

### DIFF
--- a/djongo/features.py
+++ b/djongo/features.py
@@ -3,3 +3,5 @@ from django.db.backends.base.features import BaseDatabaseFeatures
 
 class DatabaseFeatures(BaseDatabaseFeatures):
     supports_transactions = False
+    # djongo doesn't seem to support this currently
+    has_bulk_insert = False


### PR DESCRIPTION
temporary patch to fix AttributeError issue when attempting to run 'manage.py makemigrations && manage.py migrations'
The issue this temporary fix is for can be found [here](https://github.com/silentreaper/djongo/issues/1).