### PR TITLE
authorization error when connecting to mongodb with username,password and authSource

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,20 +15,6 @@ DATABASES = {
         'NAME': 'your-db-name',
     }`
 }
-With username and password
-DATABASES = {
- 'default': {
-    'ENGINE': 'djongo',
-    'NAME': 'your-db-name',
-    'HOST': 'host-name ot ip address',
-    'PORT': port-number,
-    'USER': 'db-username',
-    'PASSWORD': 'password',
-    'AUTH_SOURCE': 'db-name',
-    'AUTH_MECHANISM': 'SCRAM-SHA-1',
-     
- }`
-}
 ```
 </li>   
    <li> Run <code>manage.py makemigrations</code> followed by <code>manage.py migrate</code> (ONLY the first time to create collections in mongoDB) </li>

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ With username and password
 DATABASES = {
  'default': {
     'ENGINE': 'djongo',
-    'NAME': 'your-db-name'),
+    'NAME': 'your-db-name',
     'HOST': 'host-name ot ip address',
     'PORT': port-number,
     'USER': 'db-username',

--- a/README.md
+++ b/README.md
@@ -15,6 +15,20 @@ DATABASES = {
         'NAME': 'your-db-name',
     }`
 }
+With username and password
+DATABASES = {
+ 'default': {
+    'ENGINE': 'djongo',
+    'NAME': 'your-db-name'),
+    'HOST': 'host-name ot ip address',
+    'PORT': port-number,
+    'USER': 'db-username',
+    'PASSWORD': 'password',
+    'AUTH_SOURCE': 'db-name',
+    'AUTH_MECHANISM': 'SCRAM-SHA-1',
+     
+ }`
+}
 ```
 </li>   
    <li> Run <code>manage.py makemigrations</code> followed by <code>manage.py migrate</code> (ONLY the first time to create collections in mongoDB) </li>

--- a/djongo/base.py
+++ b/djongo/base.py
@@ -89,7 +89,11 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         connection_params = {
             'name': self.settings_dict.get('NAME', 'djongo_test') or 'djongo_test',
             'host': self.settings_dict['HOST'] or None,
-            'port': self.settings_dict['PORT'] or None
+            'port': self.settings_dict['PORT'] or None,
+            'username': self.settings_dict['USER'] or None,
+            'password': self.settings_dict['PASSWORD'] or None,
+            'authSource': self.settings_dict['AUTH_SOURCE'] or None,
+            'authMechanism': self.settings_dict['AUTH_MECHANISM'] or None,
         }
 
         return connection_params


### PR DESCRIPTION
 File "C:\Anaconda3\lib\site-packages\django\utils\autoreload.py", line 227, in wrapper
    fn(*args, **kwargs)
  File "C:\Anaconda3\lib\site-packages\django\core\management\commands\runserver.py", line 128, in inner_run
    self.check_migrations()
  File "C:\Anaconda3\lib\site-packages\django\core\management\base.py", line 422, in check_migrations
    executor = MigrationExecutor(connections[DEFAULT_DB_ALIAS])
  File "C:\Anaconda3\lib\site-packages\django\db\migrations\executor.py", line 20, in __init__
    self.loader = MigrationLoader(self.connection)
  File "C:\Anaconda3\lib\site-packages\django\db\migrations\loader.py", line 52, in __init__
    self.build_graph()
  File "C:\Anaconda3\lib\site-packages\django\db\migrations\loader.py", line 209, in build_graph
    self.applied_migrations = recorder.applied_migrations()
  File "C:\Anaconda3\lib\site-packages\django\db\migrations\recorder.py", line 65, in applied_migrations
    self.ensure_schema()
  File "C:\Anaconda3\lib\site-packages\django\db\migrations\recorder.py", line 52, in ensure_schema
    if self.Migration._meta.db_table in self.connection.introspection.table_names(self.connection.cursor()):
  File "C:\Anaconda3\lib\site-packages\django\db\backends\base\introspection.py", line 55, in table_names
    return get_names(cursor)
  File "C:\Anaconda3\lib\site-packages\django\db\backends\base\introspection.py", line 50, in get_names
    return sorted(ti.name for ti in self.get_table_list(cursor)
  File "C:\Anaconda3\lib\site-packages\djongo\introspection.py", line 9, in get_table_list
    return [TableInfo(c,'t') for c in cursor.mongo_conn.collection_names(False)]
  File "C:\Anaconda3\lib\site-packages\pymongo\database.py", line 555, in collection_names
    results = self._list_collections(sock_info, slave_okay)
  File "C:\Anaconda3\lib\site-packages\pymongo\database.py", line 527, in _list_collections
    cursor = self._command(sock_info, cmd, slave_okay)["cursor"]
  File "C:\Anaconda3\lib\site-packages\pymongo\database.py", line 428, in _command
    parse_write_concern_error=parse_write_concern_error)
  File "C:\Anaconda3\lib\site-packages\pymongo\pool.py", line 477, in command
    collation=collation)
  File "C:\Anaconda3\lib\site-packages\pymongo\network.py", line 116, in command
    parse_write_concern_error=parse_write_concern_error)
  File "C:\Anaconda3\lib\site-packages\pymongo\helpers.py", line 210, in _check_command_response
    raise OperationFailure(msg % errmsg, code, response)
pymongo.errors.OperationFailure: not authorized on testDevDB to execute command { listCollections: 1, cursor: {} }

I have resolved the issue by changing the base.py **get_connection_params** method 
write now  indie this methodconnection_param  has only had three attributes **name, host, port,**
so I have modified 
 connection_params = {
            'name': self.settings_dict.get('NAME', 'djongo_test') or 'djongo_test',
            'host': self.settings_dict['HOST'] or None,
            'port': self.settings_dict['PORT'] or None,
            'username': self.settings_dict['USER'] or None,
            'password': self.settings_dict['PASSWORD'] or None,
            'authSource': self.settings_dict['AUTH_SOURCE'] or None,
            'authMechanism': self.settings_dict['AUTH_MECHANISM'] or None,
        } 