### PR TITLE
bugfix: _id field instead of id

### DIFF
--- a/djongo/sql2mongo/query.py
+++ b/djongo/sql2mongo/query.py
@@ -253,16 +253,17 @@ class SelectQuery(Query):
             sql_tokens = self.selected_columns.sql_tokens
 
         for selected in sql_tokens:
+            selected_column = '_id' if selected.column == 'id' else selected.column
             if selected.table == self.left_table:
                 try:
-                    ret.append(doc[selected.column])
+                    ret.append(doc[selected_column])
                 except KeyError:
-                    raise MigrationError(selected.column)
+                    raise MigrationError(selected_column)
             else:
                 try:
-                    ret.append(doc[selected.table][selected.column])
+                    ret.append(doc[selected.table][selected_column])
                 except KeyError:
-                    raise MigrationError(selected.column)
+                    raise MigrationError(selected_column)
 
         return tuple(ret)
 


### PR DESCRIPTION
i get this error:
djongo.sql2mongo.SQLDecodeError: FAILED SQL: SELECT "myapp_telegrammessage"."id", "myapp_telegrammessage"."user", "myapp_telegrammessage"."channel", "myapp_telegrammessage"."date", "myapp_telegrammessage"."editdate", "myapp_telegrammessage"."messageid", "myapp_telegrammessage"."message", "myapp_telegrammessage"."views" FROM "myapp_telegrammessage" ORDER BY "myapp_telegrammessage"."id" DESC LIMIT 100
Version: 1.2.20

and after this change my program worked