### PR TITLE
Add support for UUID field to store in binary format

### DIFF
--- a/djongo/features.py
+++ b/djongo/features.py
@@ -5,3 +5,4 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_transactions = False
     # djongo doesn't seem to support this currently
     has_bulk_insert = False
+    has_native_uuid_field = True


### PR DESCRIPTION
As MongoDB has native UUID field then we can add support as a feature to store UUID as binary (instead of string) in database.
This feature is checked inside Django's UUID native field while preparing the value to store in DB.

from  **django/db/models/fields/__init__.py**:
```python
class UUIDField(Field):
    default_error_messages = {
        'invalid': _("'%(value)s' is not a valid UUID."),
    }
    description = 'Universally unique identifier'
    empty_strings_allowed = False

    def __init__(self, verbose_name=None, **kwargs):
        kwargs['max_length'] = 32
        super().__init__(verbose_name, **kwargs)

    def deconstruct(self):
        name, path, args, kwargs = super().deconstruct()
        del kwargs['max_length']
        return name, path, args, kwargs

    def get_internal_type(self):
        return "UUIDField"

    def get_db_prep_value(self, value, connection, prepared=False):
        if value is None:
            return None
        if not isinstance(value, uuid.UUID):
            value = self.to_python(value)

        if connection.features.has_native_uuid_field:  # <--- CHECK IS HERE
            return value
        return value.hex

    def to_python(self, value):
        if value is not None and not isinstance(value, uuid.UUID):
            try:
                return uuid.UUID(value)
            except (AttributeError, ValueError):
                raise exceptions.ValidationError(
                    self.error_messages['invalid'],
                    code='invalid',
                    params={'value': value},
                )
        return value

    def formfield(self, **kwargs):
        defaults = {
            'form_class': forms.UUIDField,
        }
        defaults.update(kwargs)
        return super().formfield(**defaults)
```

Fixes #98 