### PR TITLE
enc: use SystemExit instead of sys.exit

### DIFF
--- a/tests/django_tests/tests/runtests.py
+++ b/tests/django_tests/tests/runtests.py
@@ -177,8 +177,7 @@ def setup(verbosity, test_labels, parallel):
     # without raising AppRegistryNotReady when running gis_tests in isolation
     # on some backends (e.g. PostGIS).
     if 'gis_tests' in test_labels_set and not connection.features.gis_enabled:
-        print('Aborting: A GIS database backend is required to run gis_tests.')
-        sys.exit(1)
+        raise SystemExit('Aborting: A GIS database backend is required to run gis_tests.')
 
     # Load all the test model apps.
     test_modules = get_test_modules()
@@ -477,4 +476,4 @@ if __name__ == "__main__":
             options.exclude_tags,
         )
         if failures:
-            sys.exit(1)
+            raise SystemExit(1)


### PR DESCRIPTION
it's better to use SystemExit instead of sys.exit.

python docs:
https://docs.python.org/3/library/exceptions.html#SystemExit