### PR TITLE
Fix issue with `iexact` operator. Seems like misprint.

### DIFF
--- a/djongo/base.py
+++ b/djongo/base.py
@@ -80,7 +80,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
 
     operators = {
         'exact': '= %s',
-        'iexact': 'iLIKE %.*s',
+        'iexact': 'iLIKE %s',
         'contains': 'LIKE %s',
         'icontains': 'iLIKE %s',
         'regex': 'REGEXP BINARY %s',


### PR DESCRIPTION
# Description
Original issue you can observe when you have password_reset functionality from django's standart deployment. It uses `iexact` to get the user based on provided `email` (case insensitive).

## Exception:
```
~/.virtualenvs/app/lib/python3.6/site-packages/django/db/models/lookups.py in get_rhs_op(self, connection, rhs)
    165
    166     def get_rhs_op(self, connection, rhs):
--> 167         return connection.operators[self.lookup_name] % rhs
    168
    169

TypeError: * wants int
```

## After fix:
### SQL:
```sql
SELECT "auth_user"."id", "auth_user"."password", "auth_user"."last_login", "auth_user"."is_superuser", "auth_user"."username", "auth_user"."first_name", "auth_user"."last_name", "auth_user"."email", "auth_user"."is_staff", "auth_user"."is_active", "auth_user"."date_joined" FROM "auth_user" WHERE "auth_user"."email" iLIKE %s
```
```
PARAMS = ('user_email@example.com',); args=('user_email@example.com',)
```
### Mongo:
```json
{  
   "filter":{  
      "email":{  
         "$regex":"^user_email@example.com$",
         "$options":"i"
      }
   },
   "projection":[  
      "id",
      "password",
      "last_login",
      "is_superuser",
      "username",
      "first_name",
      "last_name",
      "email",
      "is_staff",
      "is_active",
      "date_joined"
   ]
}
```
Fixes #120 