### PR TITLE
Added Binary Method

### DIFF
--- a/djongo/database.py
+++ b/djongo/database.py
@@ -39,3 +39,7 @@ class ProgrammingError(DatabaseError):
 
 class NotSupportedError(DatabaseError):
     pass
+
+
+def Binary(value):
+    return value


### PR DESCRIPTION
python=3.6.5
django=2.0.6
djangorestframework=3.8.2
djongo=1.2.23
pymongo=3.7.0

When trying to save binary data using the Django BinaryField attribute on a Model object, such as:

```python
class FileChunk(models.Model):
	data = models.BinaryField()
```
and saving:
```python
chunk = FileChunk(
data = b'\x00\x46\xFE'
)
chunk.save()
```
I was confronted with the following error:
```bash
  File "/usr/local/anaconda3/envs/project/lib/python3.6/site-packages/django/db/models/fields/__init__.py", line 2320, in get_db_prep_value
    return connection.Database.Binary(value)
AttributeError: module 'djongo.database' has no attribute 'Binary'
```

According to the Django documentation (https://docs.djangoproject.com/en/2.0/howto/custom-model-fields/#converting-query-values-to-database-values), for BinaryField data the database object is expected to have a "Binary" attribute to pass the binary data, perform any necessary manipulation of the data, and return it to Django. The Djongo database object did not have this method. This PR provides this method and returns the binary data unmodified. Adding this method resolves the error, and after running the save() method, my mongo database now shows that I have the following document with the "data" having BinData() as expected:

```bash
> db.models_filechunk.findOne()
{
	"_id" : ObjectId("5b42afb90592465a907611ff"),
	"id" : 34,
	"data" : BinData(0,"JVBERi0xLj.......
```
