### PR TITLE
Bug fix for issue #178

### DIFF
--- a/djongo/models/fields.py
+++ b/djongo/models/fields.py
@@ -851,8 +851,10 @@ def create_forward_array_reference_manager(superclass, rel):
                 fks = set()
                 setattr(self.instance, self.field.get_attname(), fks)
 
+            fks = set(fks)
             new_fks = set()
             rh_field = self.field.foreign_related_fields[0]
+
             for obj in objs:
                 new_fks.add(getattr(obj, rh_field.get_attname()))
             fks.update(new_fks)


### PR DESCRIPTION
The problem was in the fks local variable in add method of ArrayReferenceManager.
We need a set to performe update method in line: 859 in fields.py file, but this variable sets to set only when the ArrayReferenceField is None.
So I've added new line in line 854 to make that variable set always