### PR TITLE
WIP: Try with raw function call on queryset (not finished)

### DIFF
--- a/djongo/cursor.py
+++ b/djongo/cursor.py
@@ -13,6 +13,8 @@ class Cursor:
         self.db_conn = db_conn
         self.client_conn = client_conn
         self.connection_properties = connection_properties
+        # raw query mush have primary key
+        self.description = [['_id']]
         self.result = None
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -32,6 +34,11 @@ class Cursor:
             return getattr(self.db_conn, name)
         except AttributeError:
             raise
+
+    def __iter__(self):
+        for doc in self.result:
+            yield doc
+
 
     @property
     def rowcount(self):


### PR DESCRIPTION
Try to implement raw function of queryset, so that pymongo query can be used directly. Here is a sample usage for text search
`model.objects.raw({"$text": {"$search": key_word}})`

Not finished and blocked by some further process logic in django's `RawQuerySet` class. So in `resolve_model_init_order` function, django need to parse out `model_init_names`, which comes from `RawQuery.get_columns` function, and this is acquired from `self.cursor.description`, which we can't get from just change db connection level in `Cursor` class in djongo. I tried to add a mongodb doc field `_id` but doesn't seem to be right. 

Transient solution is to implement some customised QuerySet to call pymongo function directly:
```
class DjongoModelQuerySet(models.QuerySet):
    def find_filter(self, query):
        """
        This is using find operation to search text, can't be used together with filter
        :return:
        """
        mongo_client = connection.client_connection
        db_name = connection.settings_dict['NAME']
        collection_name = self.model._meta.db_table

        for obj in mongo_client[db_name][collection_name].find(query):
            yield obj
```