### PR TITLE
Default for ArrayReferenceManager.attname is Set()

### DIFF
--- a/djongo/models/fields.py
+++ b/djongo/models/fields.py
@@ -905,7 +905,7 @@ def create_forward_array_reference_manager(superclass, rel):
                     }
                 }
             )
-            setattr(self.instance, self.field.attname, {})
+            setattr(self.instance, self.field.attname, set())
 
         clear.alters_data = True
 


### PR DESCRIPTION
After clearing ArrayReferenceManager fields attname property should be a Set. Otherwise it throws error if immediately invoked add method