### PR TITLE
Reorder limit and offset in aggregation select query.

### DIFF
--- a/djongo/sql2mongo/query.py
+++ b/djongo/sql2mongo/query.py
@@ -226,13 +226,13 @@ class SelectQuery(Query):
             self.order.__class__ = AggOrderConverter
             pipeline.append(self.order.to_mongo())
 
-        if self.limit:
-            self.limit.__class__ = AggLimitConverter
-            pipeline.append(self.limit.to_mongo())
-        
         if self.offset:
             self.offset.__class__ = AggOffsetConverter
             pipeline.append(self.offset.to_mongo())
+
+        if self.limit:
+            self.limit.__class__ = AggLimitConverter
+            pipeline.append(self.limit.to_mongo())
 
         if (
             not (


### PR DESCRIPTION
This PR is to fix a bug with SelectQuery building wrong pipeline when dealing with aggregations. 

Creation of `offset` pipeline step should be before that of `limit` step. Otherwise, query such as `ModelA.objects.all()[10:15]` will always return empty, given that `ModelA` is derived from another `ModelB`, which involves aggregation transformation. 
