### PR TITLE
Fixed bug in queries with multiple filters and IS NULL

### DIFF
--- a/djongo/sql2mongo/operators.py
+++ b/djongo/sql2mongo/operators.py
@@ -441,8 +441,6 @@ class ParenthesisOp(_Op):
                 op = IsOp(**kw)
                 link_op()
                 self._op_precedence(op)
-                for _ in range(3):
-                    tok_id, _ = token.token_next(tok_id)
 
             elif isinstance(tok, Comparison):
                 op = CmpOp(0, tok, self.query)


### PR DESCRIPTION
This is the original filter
db_model.objects.filter(user_id=user.id, private=False, deleted=None).count()

and this is the final query built
{ aggregate: "db_collection", pipeline: [ { $match: { deleted: null } }, { $count: "_count" } ]

The order of evaluation of filters is: deleted, private, user_id

when processing 'deleted' it was reading wrongly the params and it finally only adds that filter to the query.

It looks a copy/paste bug with BETWEEN operator

@nesdis 