### PR TITLE
Update introspection.py

### DIFF
--- a/djongo/introspection.py
+++ b/djongo/introspection.py
@@ -43,7 +43,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
 
         return [
             TableInfo(c, 't')
-            for c in cursor.db_conn.collection_names(False)
+            for c in cursor.db_conn.list_collection_names(False)
             if c != '__schema__'
         ]
 


### PR DESCRIPTION
collection_names is deprecated. So pymongo recommends use list_collection_names instead.
Otherwise, it raises an exception when you have a connection with MongoDB Cloud.