### PR TITLE
Add index type

### DIFF
--- a/djongo/introspection.py
+++ b/djongo/introspection.py
@@ -3,6 +3,7 @@ import datetime
 
 import bson
 from django.db.backends.base.introspection import BaseDatabaseIntrospection, FieldInfo, TableInfo
+from django.db.models import Index
 
 
 class DatabaseIntrospection(BaseDatabaseIntrospection):
@@ -66,6 +67,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
                 'orders': orders,
                 "foreign_key": False,
                 "check": False,
+                'type': Index.suffix
             }
         return constraint
 


### PR DESCRIPTION
While running an AlterField operation migration Django expects a `type` field in the index information. MongoDB does not return such a field and the migration therefore fails.

 
Steps to replicate the issue: Use a custom `User` class in your Django app by updating the `AUTH_USER_MODEL` parameter in your settings.py and add `django-oauth-toolkit` to your requirements.txt 

Once you've installed the `django-oauth-toolkit` try running `manage.py migrate`