### PR TITLE
Switching from django.utils.six to six

### DIFF
--- a/djongo/operations.py
+++ b/djongo/operations.py
@@ -1,8 +1,9 @@
 import pytz
 from django.conf import settings
 from django.db.backends.base.operations import BaseDatabaseOperations
-from django.utils import six, timezone
+from django.utils import timezone
 import datetime, calendar
+import six
 
 
 class DatabaseOperations(BaseDatabaseOperations):

--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,7 @@ setup(
         'pymongo>=3.2.0',
         'django>=2.0',
         'dataclasses>=0.1',
+        'six>=1.13.0',
     ],
     extras_require=dict(
         json=[


### PR DESCRIPTION
django.utils.six removed, six added in requirements. 
Fix for issue: https://github.com/nesdis/djongo/issues/341