### PR TITLE
Remove bson==0.5.8 and dataclasses>=0.1 when the python version is greater than 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,6 @@ setup(
     description=(
         'Driver for allowing Django to use MongoDB as the database backend.'),
     install_requires=[
-        'bson==0.5.8',
         'sqlparse==0.2.4',
         'pymongo>=3.2.0',
         'django>=2.0,<3',

--- a/setup.py
+++ b/setup.py
@@ -100,12 +100,7 @@ setup(
     author_email='nesdis@gmail.com',
     description=(
         'Driver for allowing Django to use MongoDB as the database backend.'),
-    install_requires=[
-        'sqlparse==0.2.4',
-        'pymongo>=3.2.0',
-        'django>=2.0,<3',
-        'six>=1.13.0',
-    ],
+    install_requires=install_requires,
     extras_require=dict(
         json=[
             'jsonfield>=2.0.2',

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,15 @@ def find_version(*file_paths):
         return version_match.group(1)
     raise RuntimeError("Unable to find version string.")
 
+install_requires=[
+  'sqlparse==0.2.4',
+  'pymongo>=3.2.0',
+  'django>=2.0,<3',
+  'six>=1.13.0',
+]
+
+if sys.version_info.major < 3 or sys.version_info.minor < 7:
+      install_requires.append("dataclasses")
 
 setup(
     name='djongo',

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,6 @@ setup(
         'sqlparse==0.2.4',
         'pymongo>=3.2.0',
         'django>=2.0,<3',
-        'dataclasses>=0.1',
         'six>=1.13.0',
     ],
     extras_require=dict(

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from setuptools import find_packages
 import os
 import codecs
 import re
+import sys
 
 LONG_DESCRIPTION = """
 


### PR DESCRIPTION
Pymongo has its own bson implementation. Installing bson creates incompatibilities with pymongo's bson, thus raising errors.