### PR TITLE
Remove bson, and dataclasses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,4 @@ before_script:
   - mongo --version
 
 script:
-  - tox #-e django_stable
-
+  - tox -e $(echo py$TRAVIS_PYTHON_VERSION | tr -d .)-django_stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 
 python:
   - "3.6"
+  - "3.7"
+  - "3.8"
 
 install:
   - wget -qO - https://www.mongodb.org/static/pgp/server-4.2.asc | sudo apt-key add -

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,6 @@ install:
   - sudo apt-get install -y mongodb-org
   - pip install tox
 
-
-env:
-  - TOX_ENV=py26-django_stable
-  - TOX_ENV=py37-django_stable
-  - TOX_ENV=py38-django_stable
-
 services: mongodb
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,5 @@ before_script:
   - mongo --version
 
 script:
-  - tox -e django_stable
+  - tox #-e django_stable
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,24 @@ install:
   - sudo apt-get install -y mongodb-org
   - pip install tox
 
+
+matrix:
+  include:
+    - python: 3.6
+      env:
+       - TOX_ENV=py26-django_stable
+    - python: 3.7
+      env:
+        - TOX_ENV=py37-django_stable
+    - python: 3.8
+      env:
+        - TOX_ENV=py38-django_stable
+
 services: mongodb
 
 before_script:
   - mongo --version
 
 script:
-  - tox -e django_stable
+  - tox -e $TOX_ENV
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,5 @@ before_script:
   - mongo --version
 
 script:
-  - tox -e $TOX_ENV
+  - tox -e django-stable
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,17 +13,10 @@ install:
   - pip install tox
 
 
-matrix:
-  include:
-    - python: 3.6
-      env:
-       - TOX_ENV=py26-django_stable
-    - python: 3.7
-      env:
-        - TOX_ENV=py37-django_stable
-    - python: 3.8
-      env:
-        - TOX_ENV=py38-django_stable
+env:
+  - TOX_ENV=py26-django_stable
+  - TOX_ENV=py37-django_stable
+  - TOX_ENV=py38-django_stable
 
 services: mongodb
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,5 @@ before_script:
   - mongo --version
 
 script:
-  - tox -e django-stable
+  - tox -e django_stable
 

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from setuptools import find_packages
 import os
 import codecs
 import re
+import sys
 
 LONG_DESCRIPTION = """
 

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,15 @@ def find_version(*file_paths):
         return version_match.group(1)
     raise RuntimeError("Unable to find version string.")
 
+install_requires=[
+  'sqlparse==0.2.4',
+  'pymongo>=3.2.0',
+  'django>=2.0,<3',
+  'six>=1.13.0',
+]
+
+if sys.version_info.major < 3 or sys.version_info.minor < 7:
+      install_requires.append("dataclasses")
 
 setup(
     name='djongo',
@@ -90,14 +99,7 @@ setup(
     author_email='nesdis@gmail.com',
     description=(
         'Driver for allowing Django to use MongoDB as the database backend.'),
-    install_requires=[
-        'bson==0.5.8',
-        'sqlparse==0.2.4',
-        'pymongo>=3.2.0',
-        'django>=2.0,<3',
-        'dataclasses>=0.1',
-        'six>=1.13.0',
-    ],
+    install_requires=install_requires,
     extras_require=dict(
         json=[
             'jsonfield>=2.0.2',

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,9 @@
 
 [tox]
 envlist =
-    django{21, _stable}
+    py36-django{21, _stable}
+    py37-django{21, _stable}
+    py38-django{21, _stable}
 
 [testenv]
 basepython =

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ envlist =
 
 [testenv]
 basepython =
-    python3.6
+    python
 
 commands_pre =
     pip install tblib

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,7 @@
 
 [tox]
 envlist =
-    py36-django{21, _stable}
-    py37-django{21, _stable}
-    py38-django{21, _stable}
+    django{21, _stable}
 
 [testenv]
 basepython =

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 envlist =
-    django{21, _stable}
+    py{36,37,38}-django{21, _stable}
 
 [testenv]
 basepython =


### PR DESCRIPTION
Pymongo has its own version of bson, which is incompatible with the package
Dataclasses is included for versions over python 3.6, making it unnecessary to install