### PR TITLE
Fix for  #387 filter __icontains is not working for the text which contains newline character 

### DIFF
--- a/djongo/sql2mongo/operators.py
+++ b/djongo/sql2mongo/operators.py
@@ -180,7 +180,7 @@ class iLikeOp(LikeOp):
     def to_mongo(self):
         return {self._field: {
             '$regex': self._regex,
-            '$options': 'i'
+            '$options': 'im'
         }}
 
 


### PR DESCRIPTION
filter __icontains is not working for the text which contains newline character #387