### PR TITLE
Django jsonfield

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,6 @@ setup(
     extras_require=dict(
         json=[
             'django-jsonfield>=1.4.0',
-            'jsonfield>=2.0.2',
             'django-jsoneditor>=0.0.12',
         ],
     ),

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,7 @@ setup(
     ],
     extras_require=dict(
         json=[
+            'django-jsonfield>=1.4.0',
             'jsonfield>=2.0.2',
             'django-jsoneditor>=0.0.12',
         ],


### PR DESCRIPTION
Okay so there has been a horrible mix-up
1. In djongo/models/json.py we are calling jsoneditor
`from jsoneditor.fields.django_jsonfield import JSONField as  JSONFieldBase`

So the module "django_jsonfield" that jsoneditor uses is from this package https://github.com/adamchainz/django-jsonfield

Meanwhile setup.py installs https://github.com/rpkilby/jsonfield which no longer has JsonFormField (which causes some issues with the jsoneditor)

2. I have issued a pull request to the jsoneditor repo too, adding the 'jsonfield' record. But I belive it will be more stable to refer to the original 'django-jsonfield' package. 