### PR TITLE
Fix AppRegistryNotReady error

### DIFF
--- a/djongo/models/fields.py
+++ b/djongo/models/fields.py
@@ -107,7 +107,7 @@ class ModelField(MongoField):
         super().__init__(*args, **kwargs)
 
     def _validate_container(self):
-        for field in self.model_container._meta.get_fields():
+        for field in self.model_container._meta._get_fields(reverse=False):
             if isinstance(field, (AutoField,
                                   BigAutoField,
                                   RelatedField)):


### PR DESCRIPTION
The checks that Djongo runs on the `model_container` requires all apps to be loaded, but the checks are run while the models are being loaded. The app can, therefore, not start.

This PR addresses this issue.