### PR TITLE
Adjust API for `sql_flush`

### DIFF
--- a/djongo/operations.py
+++ b/djongo/operations.py
@@ -90,7 +90,7 @@ class DatabaseOperations(BaseDatabaseOperations):
             converters.append(self.convert_datetimefield_value)
         return converters
 
-    def sql_flush(self, style, tables, sequences, allow_cascade=False):
+    def sql_flush(self, style, tables, reset_sequences, allow_cascade=False):
         # TODO: Need to implement this fully
         return [f'ALTER TABLE "{table}" FLUSH'
                 for table in tables]


### PR DESCRIPTION
The [`sql_flush` call](https://github.com/django/django/blob/0a306f7da668e53af2516bfad759b52d6c650b69/django/core/management/sql.py#L13) used to be only positional parameters, but now it has the last 2 called
as keyword-arguments, with the `sequences` renamed to `reset_sequences`.