### PR TITLE
add all sqlparse.tokens.Name.Builtin types

### DIFF
--- a/djongo/sql2mongo/query.py
+++ b/djongo/sql2mongo/query.py
@@ -560,6 +560,10 @@ class AlterQuery(DDLQuery):
                 print_warn('column type validation')
                 self._type_code = str(tok)
 
+            elif tok.match(tokens.Keyword, 'double'):
+                print_warn('column type validation')
+                self._type_code = str(tok)
+
             elif isinstance(tok, Identifier):
                 self._iden_name = tok.get_real_name()
 

--- a/djongo/sql2mongo/query.py
+++ b/djongo/sql2mongo/query.py
@@ -556,10 +556,7 @@ class AlterQuery(DDLQuery):
             )):
                 print_warn(f'schema validation using {tok}')
 
-            elif tok.match(tokens.Name.Builtin, (
-                'integer', 'bool', 'char', 'date', 'boolean',
-                'datetime', 'float', 'time', 'number', 'string'
-            )):
+            elif tok.match(tokens.Name.Builtin, '.*', regex=True):
                 print_warn('column type validation')
                 self._type_code = str(tok)
 


### PR DESCRIPTION
Please add all builtin types from sqlparser (https://github.com/andialbrecht/sqlparse/blob/11a6b7db8b19bf1f92754a6272839c66ee630683/sqlparse/keywords.py#L630)
or match with this regex

thanks!

PD: I only need 'int' and 'double'