### PR TITLE
GridFS Storage Manager Issues in url() and _get_gridfs()

### DIFF
--- a/djongo/storage.py
+++ b/djongo/storage.py
@@ -132,7 +132,7 @@ class GridFSStorage(Storage):
             raise ValueError("This file is not accessible via a URL.")
         gridfs, filename = self._get_gridfs(name)
         try:
-            file_oid = gridfs.get_last_version(filename=name).__getattr__('_id')
+            file_oid = gridfs.get_last_version(filename=filename).__getattr__('_id')
         except NoFile:
             # In case not found by filename
             try:

--- a/djongo/storage.py
+++ b/djongo/storage.py
@@ -165,6 +165,10 @@ class GridFSStorage(Storage):
             from django.db import connections
             self._db = connections[self.database].connection
 
+        if self._db is None: 
+            connections[self.database].connect()                                       
+            self._db = connections[self.database].connection             
+
         return GridFS(self._db, collection_name), filename
 
     def get_accessed_time(self, name):


### PR DESCRIPTION
The url() method uses the incorrect filename value when querying the GridFS for the data handle.

In a use scenario where MongoDB bound through djongo as a secondary database the GridFS supported file storage fails as the MongoDB database connection is not active. A forced connection is needed in such cases.