### PR TITLE
Add support for Django 3.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ def find_version(*file_paths):
 install_requires = [
     'sqlparse==0.2.4',
     'pymongo>=3.2.0',
-    'django>=2.1,<=3.0.5',
+    'django>=2.1',
 ]
 
 if sys.version_info.major == 3 and sys.version_info.minor < 7:

--- a/tox.ini
+++ b/tox.ini
@@ -26,9 +26,9 @@ commands =
 deps =
     Django>=2.2,<2.3
 
-[testenv:py38-django30]
+[testenv:py38-django31]
 deps =
-    Django>=3.0,<3.1
+    Django>=3.1
 
 [testenv:django22_discover]
 commands =


### PR DESCRIPTION
a simpler version of #489

tests are passing, so I'm guessing these are the only changes necessary