### PR TITLE
Adapt decimal values to bson.Decimal128

### DIFF
--- a/djongo/operations.py
+++ b/djongo/operations.py
@@ -60,6 +60,8 @@ class DatabaseOperations(BaseDatabaseOperations):
                                  value.second, value.microsecond)
     
     def adapt_decimalfield_value(self, value, max_digits=None, decimal_places=None):
+        if value is None:
+            return None
         return bson.Decimal128(super().adapt_decimalfield_value(value, max_digits, decimal_places))
 
     def convert_datefield_value(self, value, expression, connection):

--- a/djongo/operations.py
+++ b/djongo/operations.py
@@ -2,6 +2,7 @@ import pytz
 from django.conf import settings
 from django.db.backends.base.operations import BaseDatabaseOperations
 from django.utils import timezone
+import bson
 import datetime
 import calendar
 
@@ -57,6 +58,9 @@ class DatabaseOperations(BaseDatabaseOperations):
 
         return datetime.datetime(1900, 1, 1, value.hour, value.minute,
                                  value.second, value.microsecond)
+    
+    def adapt_decimalfield_value(self, value, max_digits=None, decimal_places=None):
+        return bson.Decimal128(super().adapt_decimalfield_value(value, max_digits, decimal_places))
 
     def convert_datefield_value(self, value, expression, connection):
         if isinstance(value, datetime.datetime):


### PR DESCRIPTION
Fix #378 

Django's default DatabaseOperation converts decimal values to strings to be in the SQL statement, but Djongo uses those values to form a MongoDB query statement.

This patch converts the string back to `bson.Decimal128` so that the type is preserved.